### PR TITLE
Fix #26: set trace-buffer-size works now in simple mode!

### DIFF
--- a/start_gdb.sh
+++ b/start_gdb.sh
@@ -1,0 +1,1 @@
+sudo gdb /usr/lib/debug/lib/modules/3.14.8-200.fc20.x86_64/vmlinux -ex 'target remote /sys/kernel/debug/gtp' -ex 'set remote trace-buffer-size on'

--- a/startover_gtp.sh
+++ b/startover_gtp.sh
@@ -1,0 +1,4 @@
+sudo rmmod gtp
+make clean
+make D=1
+sudo insmod gtp.ko


### PR DESCRIPTION
Now the feature **set trace-buffer-size** works in simple mode now, in this mode, if there are trace frames in current trace buffer, we will simply discard them all. The strategy for setting new size is implemented as, free the old ring buffer first, then realloc memory according to the new size specified by user.

Tests are done on Fedora 20, after running `set trace-buffer-size xxx`, you may use `show trace-buffer-size` to check. And whenever you use `tstatus`, you may find the trace buffer size is the new one. 

Main changes are performed on **gtp.c**, two utility files are added for easy debugging,
-    startover_gtp.sh
  This will remove gtp module from kernel, compile with D=1 and install gtp.ko to kernel again.
-    start_gdb.sh
  This will start GDB, setting the linux kernel symbol file(user must alter this according to the kernel used), set remote to gtp and enable set trace-buffer-size by executing `set remote trace-buffer-size on`.

For normal mode or when we must retain old trace frames, a copy of data from old ring buffer to the new one will be performed. However, this will be implemented as another new feature.
